### PR TITLE
fixed number of elements in test_number_of_elf

### DIFF
--- a/tests/test_iso20275.py
+++ b/tests/test_iso20275.py
@@ -37,7 +37,7 @@ class TestElf(unittest.TestCase):
                 self.assertEqual(elf, getattr(value, 'elf'))
 
     def test_number_of_elf(self):
-        self.assertEqual(len(Elf), 2867)
+        self.assertEqual(len(Elf), 2913)
 
     def test_254M_multiple_values(self):
         self.assertEqual(len(Elf['254M']), 2)


### PR DESCRIPTION
In current version the unit tests fail due to wrong constant in test_number_of_elf. This pull request fixes that issue.